### PR TITLE
レコードに存在しないIDをリクエストした際、例外をハンドリングする処理を実装

### DIFF
--- a/src/main/java/com/example/catsdatabase/CatController.java
+++ b/src/main/java/com/example/catsdatabase/CatController.java
@@ -2,6 +2,7 @@ package com.example.catsdatabase;
 
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +20,10 @@ public class CatController {
     @GetMapping("/cats")
     public List<Cat> findByCoats(@RequestParam String coats) {
         return catService.findByCoats(coats);
+    }
+
+    @GetMapping("/cats/{id}")
+    public Cat findCat(@PathVariable("id") int id) {
+        return catService.findCat(id);
     }
 }

--- a/src/main/java/com/example/catsdatabase/CatMapper.java
+++ b/src/main/java/com/example/catsdatabase/CatMapper.java
@@ -4,10 +4,14 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface CatMapper {
 
     @Select("SELECT * FROM cats WHERE coats LIKE CONCAT('%', #{coats}, '%')")
     List<Cat> findByCoats(String coats);
+
+    @Select("SELECT * FROM cats WHERE id = #{id}")
+    Optional<Cat> findById(Integer id);
 }

--- a/src/main/java/com/example/catsdatabase/CatNotFoundException.java
+++ b/src/main/java/com/example/catsdatabase/CatNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.catsdatabase;
+
+public class CatNotFoundException extends RuntimeException {
+
+    public CatNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/catsdatabase/CatService.java
+++ b/src/main/java/com/example/catsdatabase/CatService.java
@@ -3,6 +3,7 @@ package com.example.catsdatabase;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class CatService {
@@ -17,4 +18,12 @@ public class CatService {
         return catMapper.findByCoats(coats);
     }
 
+    public Cat findCat(Integer id) {
+        Optional<Cat> cat = catMapper.findById(id);
+        if (cat.isPresent()) {
+            return cat.get();
+        } else {
+            throw new CatNotFoundException("そのIDは存在しません。");
+        }
+    }
 }

--- a/src/main/java/com/example/catsdatabase/CatService.java
+++ b/src/main/java/com/example/catsdatabase/CatService.java
@@ -20,10 +20,6 @@ public class CatService {
 
     public Cat findCat(Integer id) {
         Optional<Cat> cat = catMapper.findById(id);
-        if (cat.isPresent()) {
-            return cat.get();
-        } else {
-            throw new CatNotFoundException("そのIDは存在しません。");
-        }
+        return cat.orElseThrow(() -> new CatNotFoundException("そのIDは存在しません。"));
     }
 }

--- a/src/main/java/com/example/catsdatabase/CustomExceptionHandler.java
+++ b/src/main/java/com/example/catsdatabase/CustomExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.catsdatabase;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(value = CatNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUserNotFoundException(
+            CatNotFoundException ex, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", ex.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
# 概要
DBのCatテーブルのレコードに存在しないIDをリクエストした際、例外をハンドリングする処理を実装しました。
その際 `@ControllerAdvice` を使用して、ハンドリングする専用のクラスを作成しました。
コミットハッシュ： c0e0a38e1cbe0403d8fb570d51ac59a4bc033e5e

# 動作確認結果
Postmanで存在しないレコードのIDリクエストをし、下記のとおり狙ったレスポンスが返ってきました。
- 404エラーになっている 。（画像1）
- CustomExceptionHandlerクラス記載のとおりの情報＆CatServiceクラス記載の文言が表示されている 。（画像1）
- Content-Type が「json」である。（画像2）

![image](https://github.com/Ema-Sakai/Assignment-9/assets/166620990/68132e71-f214-49ca-b84f-04ae99b846ea)

</br>

![image](https://github.com/Ema-Sakai/Assignment-9/assets/166620990/cf6ce153-2dd9-4400-b190-2358956dc13c)
